### PR TITLE
feat: bulk multi-select notebook assignment — closes #7

### DIFF
--- a/extensions/chrome/content_script.js
+++ b/extensions/chrome/content_script.js
@@ -21,6 +21,8 @@ const FOLDER_COLORS = [
 let FOLDERS = [];
 let ASSIGNMENTS = {};
 let ACTIVE_FILTER = 'All';
+let SELECT_MODE = false;
+let SELECTED_IDS = new Set();
 
 // --- Helpers ---
 
@@ -266,6 +268,7 @@ async function createFilterUI(targetContainer) {
     actionsWrapper.className = 'filter-bar-actions';
     actionsWrapper.appendChild(createAddFolderButton());
     actionsWrapper.appendChild(createManagerButton());
+    actionsWrapper.appendChild(createSelectModeButton());
     filterContainer.appendChild(actionsWrapper);
 
     const featuredProjectsContainer = targetContainer.querySelector('.featured-projects-container');
@@ -310,6 +313,214 @@ function createManagerButton() {
     </svg>`;
     button.addEventListener('click', openFolderManager);
     return button;
+}
+
+function createSelectModeButton() {
+    const button = document.createElement('button');
+    button.id = 'select-mode-btn';
+    button.title = 'Select notebooks';
+    button.textContent = 'Select';
+    button.addEventListener('click', () => {
+        if (SELECT_MODE) {
+            exitSelectMode();
+        } else {
+            enterSelectMode();
+        }
+    });
+    return button;
+}
+
+// --- Bulk Select Mode ---
+
+function enterSelectMode() {
+    SELECT_MODE = true;
+    SELECTED_IDS.clear();
+    const filterContainer = document.querySelector('.category-filter-container');
+    if (filterContainer) filterContainer.classList.add('select-mode-active');
+    renderBulkToolbar();
+    document.querySelectorAll('project-button, tr.mat-mdc-row').forEach(el => {
+        injectSelectCheckbox(el);
+    });
+    document.querySelectorAll('table.mdc-data-table__table thead tr').forEach(hr => {
+        injectSelectAllHeader(hr);
+    });
+}
+
+function exitSelectMode() {
+    SELECT_MODE = false;
+    SELECTED_IDS.clear();
+    const filterContainer = document.querySelector('.category-filter-container');
+    if (filterContainer) filterContainer.classList.remove('select-mode-active');
+    const toolbar = document.getElementById('bulk-action-toolbar');
+    if (toolbar) toolbar.remove();
+    document.querySelectorAll('.select-checkbox-cell, .select-checkbox-card, .select-all-header').forEach(el => el.remove());
+    document.querySelectorAll('[data-select-checked]').forEach(el => el.removeAttribute('data-select-checked'));
+}
+
+function renderBulkToolbar() {
+    const existing = document.getElementById('bulk-action-toolbar');
+    if (existing) existing.remove();
+
+    const toolbar = document.createElement('div');
+    toolbar.id = 'bulk-action-toolbar';
+    toolbar.innerHTML = `
+        <span id="bulk-selected-count">${SELECTED_IDS.size} selected</span>
+        <button id="bulk-move-btn">Move to ▾</button>
+        <button id="bulk-cancel-btn">Cancel</button>
+    `;
+
+    const filterContainer = document.querySelector('.category-filter-container');
+    if (filterContainer) {
+        filterContainer.parentNode.insertBefore(toolbar, filterContainer.nextSibling);
+    }
+
+    toolbar.querySelector('#bulk-move-btn').addEventListener('click', (e) => {
+        e.stopPropagation();
+        showBulkFolderPicker(e.target);
+    });
+    toolbar.querySelector('#bulk-cancel-btn').addEventListener('click', exitSelectMode);
+}
+
+function updateBulkToolbar() {
+    const countEl = document.getElementById('bulk-selected-count');
+    if (countEl) countEl.textContent = `${SELECTED_IDS.size} selected`;
+}
+
+function showBulkFolderPicker(triggerEl) {
+    const existing = document.querySelector('.bulk-folder-menu');
+    if (existing) { existing.remove(); return; }
+
+    const menu = document.createElement('div');
+    menu.className = 'bulk-folder-menu folder-assign-menu';
+
+    [...FOLDERS, { name: 'Uncategorized', color: undefined }].forEach(f => {
+        const name = f.name;
+        const color = f.color || null;
+        const option = document.createElement('div');
+        option.className = 'folder-assign-option';
+        if (color) {
+            const dot = document.createElement('span');
+            dot.className = 'folder-color-dot';
+            dot.style.background = color;
+            option.appendChild(dot);
+        }
+        option.appendChild(document.createTextNode(name));
+        option.addEventListener('click', async () => {
+            menu.remove();
+            await applyBulkAssignment(name);
+        });
+        menu.appendChild(option);
+    });
+
+    document.body.appendChild(menu);
+    const rect = triggerEl.getBoundingClientRect();
+    menu.style.top = (rect.bottom + window.scrollY + 4) + 'px';
+    menu.style.left = (rect.left + window.scrollX) + 'px';
+
+    const close = (e) => {
+        if (!menu.contains(e.target)) {
+            menu.remove();
+            document.removeEventListener('click', close, true);
+        }
+    };
+    setTimeout(() => document.addEventListener('click', close, true), 0);
+}
+
+async function applyBulkAssignment(folderName) {
+    SELECTED_IDS.forEach(id => {
+        if (folderName === 'Uncategorized') {
+            delete ASSIGNMENTS[id];
+        } else {
+            ASSIGNMENTS[id] = folderName;
+        }
+    });
+    try {
+        await persistAssignments();
+    } catch (err) {
+        console.error('[NotebookLM Folder Manager] Failed to persist bulk assignment:', err);
+    }
+    exitSelectMode();
+    refreshView();
+}
+
+function injectSelectCheckbox(el) {
+    const id = getNotebookId(el);
+
+    if (el.tagName === 'TR') {
+        if (el.querySelector('.select-checkbox-cell')) return;
+        const td = document.createElement('td');
+        td.className = 'select-checkbox-cell mat-mdc-cell';
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.className = 'select-cb';
+        if (id) {
+            cb.checked = SELECTED_IDS.has(id);
+            cb.addEventListener('change', () => {
+                if (cb.checked) { SELECTED_IDS.add(id); } else { SELECTED_IDS.delete(id); }
+                updateSelectAllHeader();
+                updateBulkToolbar();
+            });
+        } else {
+            cb.disabled = true;
+        }
+        td.appendChild(cb);
+        el.insertBefore(td, el.firstChild);
+    } else {
+        if (el.querySelector('.select-checkbox-card')) return;
+        const wrapper = document.createElement('label');
+        wrapper.className = 'select-checkbox-card';
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.className = 'select-cb';
+        if (id) {
+            cb.checked = SELECTED_IDS.has(id);
+            cb.addEventListener('change', (e) => {
+                e.stopPropagation();
+                if (cb.checked) { SELECTED_IDS.add(id); } else { SELECTED_IDS.delete(id); }
+                updateBulkToolbar();
+            });
+        } else {
+            cb.disabled = true;
+        }
+        wrapper.appendChild(cb);
+        el.style.position = 'relative';
+        el.insertBefore(wrapper, el.firstChild);
+    }
+}
+
+function injectSelectAllHeader(headerRow) {
+    if (headerRow.querySelector('.select-all-header')) return;
+    const th = document.createElement('th');
+    th.className = 'select-all-header mat-mdc-header-cell';
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.id = 'select-all-cb';
+    cb.title = 'Select all visible';
+    cb.addEventListener('change', () => {
+        const visible = Array.from(document.querySelectorAll('tr.mat-mdc-row[data-filtered="visible"]'));
+        visible.forEach(row => {
+            const id = getNotebookId(row);
+            if (!id) return;
+            const rowCb = row.querySelector('.select-cb');
+            if (rowCb) rowCb.checked = cb.checked;
+            if (cb.checked) { SELECTED_IDS.add(id); } else { SELECTED_IDS.delete(id); }
+        });
+        updateBulkToolbar();
+    });
+    th.appendChild(cb);
+    headerRow.insertBefore(th, headerRow.firstChild);
+}
+
+function updateSelectAllHeader() {
+    const cb = document.getElementById('select-all-cb');
+    if (!cb) return;
+    const visible = Array.from(document.querySelectorAll('tr.mat-mdc-row[data-filtered="visible"]'));
+    const allChecked = visible.length > 0 && visible.every(row => {
+        const id = getNotebookId(row);
+        return id && SELECTED_IDS.has(id);
+    });
+    cb.checked = allChecked;
+    cb.indeterminate = !allChecked && SELECTED_IDS.size > 0;
 }
 
 // --- Folder Manager Modal ---
@@ -477,9 +688,11 @@ function injectAssignButtons() {
     // Re-inject column header if table re-rendered
     document.querySelectorAll('table.mdc-data-table__table thead tr').forEach(hr => {
         injectFolderColumnHeader(hr);
+        if (SELECT_MODE) injectSelectAllHeader(hr);
     });
     document.querySelectorAll('project-button, tr.mat-mdc-row').forEach(el => {
         injectAssignButton(el);
+        if (SELECT_MODE) injectSelectCheckbox(el);
     });
 }
 

--- a/extensions/chrome/style.css
+++ b/extensions/chrome/style.css
@@ -101,6 +101,89 @@ tr.mat-mdc-row[data-filtered="hidden"] {
     stroke-width: 1.5;
 }
 
+/* --- Select Mode Button --- */
+#select-mode-btn {
+    padding: 7px 16px;
+    border: 1px solid rgba(28, 28, 28, 0.12);
+    border-radius: 2px 12px 2px 12px;
+    background-color: transparent;
+    color: #4A4A4A;
+    cursor: pointer;
+    font-size: 0.85em;
+    transition: all 0.35s cubic-bezier(0.23, 1, 0.32, 1);
+    white-space: nowrap;
+}
+#select-mode-btn:hover {
+    background-color: rgba(28, 28, 28, 0.04);
+    border-color: rgba(28, 28, 28, 0.25);
+}
+.select-mode-active #select-mode-btn {
+    background-color: rgba(28, 28, 28, 0.06);
+    border-color: rgba(28, 28, 28, 0.25);
+}
+
+/* --- Bulk Action Toolbar --- */
+#bulk-action-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 16px;
+    background: rgba(28, 28, 28, 0.03);
+    border-bottom: 1px solid rgba(28, 28, 28, 0.06);
+    font-size: 0.9em;
+    color: #4A4A4A;
+}
+#bulk-selected-count {
+    font-weight: 500;
+    color: #1C1C1C;
+}
+#bulk-move-btn {
+    padding: 6px 14px;
+    border: 1px solid rgba(28, 28, 28, 0.15);
+    border-radius: 2px 10px 2px 10px;
+    background: transparent;
+    cursor: pointer;
+    font-size: 0.9em;
+    color: #1C1C1C;
+    transition: all 0.25s ease;
+}
+#bulk-move-btn:hover {
+    background: rgba(28, 28, 28, 0.05);
+}
+#bulk-cancel-btn {
+    padding: 6px 14px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: 0.9em;
+    color: #8B8B8B;
+    transition: color 0.2s ease;
+}
+#bulk-cancel-btn:hover {
+    color: #1C1C1C;
+}
+
+/* --- Select checkboxes --- */
+.select-checkbox-cell,
+.select-all-header {
+    width: 36px;
+    padding: 8px 12px;
+    vertical-align: middle;
+}
+.select-checkbox-card {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 6;
+    cursor: pointer;
+}
+.select-cb {
+    cursor: pointer;
+    width: 16px;
+    height: 16px;
+    accent-color: #1C1C1C;
+}
+
 /* --- Folder Manager Modal --- */
 .category-manager-overlay {
     position: fixed;


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #7.

Adds a "Select" mode that lets users check multiple notebooks and bulk-assign them to a folder at once.

## Changes
- `SELECT_MODE` + `SELECTED_IDS` global state
- "Select" toggle button in filter bar actions
- `enterSelectMode()` / `exitSelectMode()` manage checkbox injection and cleanup
- Table rows: checkbox `<td>` prepended (`.select-checkbox-cell`)
- Card view: checkbox overlay `<label>` (`.select-checkbox-card`)
- "Select All Visible" checkbox in table header with indeterminate state (`updateSelectAllHeader`)
- Bulk-action toolbar (`#bulk-action-toolbar`): "X selected", "Move to ▾", "Cancel"
- "Move to ▾" opens folder picker (`showBulkFolderPicker`) — assigns all selected and persists
- Checkbox column hidden outside select mode (no layout shift)
- CSS: select-mode toggle, bulk toolbar, checkbox cell styles

## Acceptance criteria
- [x] "Select" toggle button in the filter bar activates checkbox column
- [x] "Select all visible" checkbox in the header row
- [x] Bulk-action toolbar appears when ≥1 notebook is selected, showing a folder picker
- [x] Selecting a folder from the picker assigns all selected notebooks and persists
- [x] Checkbox column is hidden outside select mode (no layout shift for normal use)

Closes #7