### PR TITLE
feat: keyboard shortcuts for folder navigation and manager — closes #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Click the folder tag on any notebook row to open a dropdown and pick a folder. T
 
 Click any folder tab in the filter bar to show only notebooks in that folder. Click **All** to reset.
 
+### Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Alt+F` | Open / close the Folder Manager modal |
+| `Alt+1` … `Alt+9` | Switch to filter tab 1–9 (`All` = `Alt+1`, first folder = `Alt+2`, …) |
+| `Escape` | Close the Folder Manager modal |
+
+Shortcuts are suppressed when focus is inside a text input.
+
 ---
 
 ## FAQ

--- a/extensions/chrome/content_script.js
+++ b/extensions/chrome/content_script.js
@@ -43,6 +43,7 @@ function normaliseFolders(raw) {
 
 async function init() {
     await loadFolders();
+    registerKeyboardShortcuts();
 
     document.arrive(
         '.all-projects-container',
@@ -957,6 +958,49 @@ function refreshView() {
     const activeFilter = activeBtn ? activeBtn.getAttribute('data-category') : 'All';
     filterProjects(activeFilter);
     injectAssignButtons();
+}
+
+// --- Keyboard Shortcuts ---
+
+/**
+ * Registers keyboard shortcuts for folder navigation and manager.
+ *
+ * Shortcut table:
+ *   Alt+F        Open / close the Folder Manager modal
+ *   Alt+1–Alt+9  Switch to filter tab 1–9 (All = Alt+1, first folder = Alt+2, …)
+ *   Escape       Close folder manager modal
+ *
+ * Shortcuts are suppressed when focus is inside a text input or textarea.
+ */
+function registerKeyboardShortcuts() {
+    document.addEventListener('keydown', (e) => {
+        // Suppress when typing in an input
+        const tag = document.activeElement && document.activeElement.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || document.activeElement.isContentEditable) return;
+
+        if (e.key === 'Escape') {
+            closeFolderManager();
+            return;
+        }
+
+        if (e.altKey && e.key === 'f') {
+            e.preventDefault();
+            const existing = document.getElementById('category-manager-overlay');
+            if (existing) {
+                closeFolderManager();
+            } else {
+                openFolderManager();
+            }
+            return;
+        }
+
+        if (e.altKey && e.key >= '1' && e.key <= '9') {
+            e.preventDefault();
+            const idx = parseInt(e.key, 10) - 1; // 0-based
+            const buttons = Array.from(document.querySelectorAll('.category-filter-button'));
+            if (buttons[idx]) buttons[idx].click();
+        }
+    });
 }
 
 init();


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #9.

Adds keyboard shortcuts registered via `document.addEventListener('keydown', ...)`. Shortcuts are suppressed when focus is inside any text input.

## Changes
- `registerKeyboardShortcuts()` called from `init()` — single listener, no cleanup needed
- `Alt+F`: toggles folder manager modal (opens if closed, closes if open)
- `Alt+1`–`Alt+9`: clicks the corresponding `.category-filter-button` by 0-based index
- `Escape`: closes the folder manager modal
- Guard: checks `activeElement.tagName` for INPUT/TEXTAREA and `isContentEditable`
- README: keyboard shortcuts table added under the Filtering section

## Acceptance criteria
- [x] `Alt+F` toggles the folder manager modal
- [x] `Alt+1`–`Alt+9` activate the corresponding filter tab (no-op if fewer tabs exist)
- [x] `Escape` closes an open modal
- [x] Shortcuts are suppressed when focus is inside a text input
- [x] README is updated with a shortcuts table

Closes #9